### PR TITLE
Fix image output in CycleGAN

### DIFF
--- a/CycleGAN/CycleGAN.py
+++ b/CycleGAN/CycleGAN.py
@@ -646,9 +646,6 @@ class CycleGAN():
             synthetic = synthetic[0]
             reconstructed = reconstructed[0]
 
-        synthetic = synthetic.clip(min=0)
-        reconstructed = reconstructed.clip(min=0)
-
         # Append and save
         if real_ is not None:
             if len(real_.shape) > 4:
@@ -660,7 +657,7 @@ class CycleGAN():
         if self.channels == 1:
             image = image[:, :, 0]
 
-        toimage(image, cmin=0, cmax=1).save(path_name)
+        toimage(image, cmin=-1, cmax=1).save(path_name)
 
     def saveImages(self, epoch, real_image_A, real_image_B, num_saved_images=1):
         directory = os.path.join('images', self.date_time)
@@ -842,8 +839,7 @@ class CycleGAN():
             def save_image(image, name, domain):
                 if self.channels == 1:
                     image = image[:, :, 0]
-                image = image.clip(min=0)
-                toimage(image, cmin=0, cmax=1).save(os.path.join(
+                toimage(image, cmin=-1, cmax=1).save(os.path.join(
                     'generate_images', 'synthetic_images', domain, name))
 
             # Test A images


### PR DESCRIPTION
Hi Simon,

It seems you forgot to change the code for outputting the images when fixing the image normalization :) As it is now the GAN outputs images in the -1 to 1 range, but then only the positive values are saved.

/David