### PR TITLE
Fix PatchGAN size in CycleGAN

### DIFF
--- a/CycleGAN/CycleGAN.py
+++ b/CycleGAN/CycleGAN.py
@@ -245,8 +245,8 @@ class CycleGAN():
 #===============================================================================
 # Architecture functions
 
-    def ck(self, x, k, use_normalization):
-        x = Conv2D(filters=k, kernel_size=4, strides=2, padding='same')(x)
+    def ck(self, x, k, use_normalization, stride):
+        x = Conv2D(filters=k, kernel_size=4, strides=stride, padding='same')(x)
         # Normalization is not done on the first discriminator layer
         if use_normalization:
             x = self.normalization(axis=3, center=True, epsilon=1e-5)(x, training=True)
@@ -308,13 +308,13 @@ class CycleGAN():
         # Specify input
         input_img = Input(shape=self.img_shape)
         # Layer 1 (#Instance normalization is not used for this layer)
-        x = self.ck(input_img, 64, False)
+        x = self.ck(input_img, 64, False, 2)
         # Layer 2
-        x = self.ck(x, 128, True)
+        x = self.ck(x, 128, True, 2)
         # Layer 3
-        x = self.ck(x, 256, True)
+        x = self.ck(x, 256, True, 2)
         # Layer 4
-        x = self.ck(x, 512, True)
+        x = self.ck(x, 512, True, 1)
         # Output layer
         if self.use_patchgan:
             x = Conv2D(filters=1, kernel_size=4, strides=1, padding='same')(x)


### PR DESCRIPTION
Hi Simon :-)

In the original CycleGAN paper they mention using a 70x70 PatchGAN. This refers to the receptive field of the discriminator, which is set by the number of layers and the stride of each layer. In order to get a size of 70 only the first 3 discriminator layers have to have stride 2. With the current implementation (4 layers with stride 2) the receptive field of the discriminator is 94. You can check [this](https://drive.google.com/file/d/16EB5imuBnXnHVcen0b2NXFTm7j3TUY-J/view?usp=sharing) little thing I wrote deriving the relationships between number of layers, stride, and receptive field.

It probably makes sense to make this parameter easy to modify, as the optimum is likely dependent on the size of the images.

/David